### PR TITLE
Clean up overview option (-o) code

### DIFF
--- a/ethertype.h
+++ b/ethertype.h
@@ -216,4 +216,11 @@
 #define	ETHERTYPE_ARISTA        0xd28b /*  Arista Networks vendor specific EtherType */
 #endif
 
+/*
+ * Length of an Ethernet header; note that some compilers may pad
+ * "struct ether_header" to a multiple of 4 bytes, for example, so
+ * "sizeof (struct ether_header)" may not give the right answer.
+ */
+#define ETHER_HDRLEN		14
+
 extern const struct tok ethertype_values[];

--- a/netdissect.h
+++ b/netdissect.h
@@ -237,6 +237,8 @@ struct netdissect_options {
   const u_char *ndo_packetp;
   const u_char *ndo_snapend;
 
+  int ndo_dlt; /* datalink type */
+
   /* stack of saved packet boundary and buffer information */
   struct netdissect_saved_packet_info *ndo_packet_info_stack;
 

--- a/print-ether.c
+++ b/print-ether.c
@@ -42,13 +42,6 @@ struct	ether_header {
 	nd_uint16_t	ether_length_type;
 };
 
-/*
- * Length of an Ethernet header; note that some compilers may pad
- * "struct ether_header" to a multiple of 4 bytes, for example, so
- * "sizeof (struct ether_header)" may not give the right answer.
- */
-#define ETHER_HDRLEN		14
-
 const struct tok ethertype_values[] = {
     { ETHERTYPE_IP,		"IPv4" },
     { ETHERTYPE_MPLS,		"MPLS unicast" },


### PR DESCRIPTION
This PR cleans up the code from [PR 1](https://github.com/legrand-home-systems-mdt/tcpdump/pull/1).

I tested it by running tcpdump with and without the -o option.  I also ran "make check" to do all of the regression tests.